### PR TITLE
Running notebooks in CI

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -1,0 +1,26 @@
+name: Notebooks
+on: push
+
+jobs:
+  run-notebooks:
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mamba-org/setup-micromamba@v1.8.1
+        with:
+          environment-file: environment.yml
+          cache-environment: true
+
+      - name: Check GPU availability
+        shell: bash -l {0}
+        run: |
+          python -c "import torch; print('Is CUDA available:', torch.cuda.is_available())"
+
+      - name: Run notebooks
+        shell: bash -l {0}
+        run: |
+          set -e
+          export PYTHONPATH=${PWD}:$PYTHONPATH
+          for file in examples/*.ipynb; do
+            jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=300 "$file"
+          done

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - scikit-learn
     - pydoclint
     - coverage
+    - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,3 @@ dependencies:
     - scikit-learn
     - pydoclint
     - coverage
-    - jupyter


### PR DESCRIPTION
This PR adds a workflow that tests that all notebooks under `examples/` run correctly. It will trigger on every push.

This test is a separate runner from CI because it needs a GPU (cpu version is too slow).

If we find that this test uses too much of our compute budget, we can reduce the frequency of the runs.

A single run takes 8m30s.