### PR TITLE
Removed no_grad from solver

### DIFF
--- a/flow_matching/solver/discrete_solver.py
+++ b/flow_matching/solver/discrete_solver.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 from flow_matching.path import MixtureDiscreteProbPath
 
 from flow_matching.solver.solver import Solver
+from flow_matching.solver.utils import toggle_grad
 from flow_matching.utils import categorical, ModelWrapper
 from .utils import get_nearest_times
 
@@ -82,7 +83,7 @@ class MixtureDiscreteEulerSolver(Solver):
 
         self.source_distribution_p = source_distribution_p
 
-    @torch.no_grad()
+    @toggle_grad
     def sample(
         self,
         x_init: Tensor,

--- a/flow_matching/solver/ode_solver.py
+++ b/flow_matching/solver/ode_solver.py
@@ -11,6 +11,7 @@ from torch import Tensor
 from torchdiffeq import odeint
 
 from flow_matching.solver.solver import Solver
+from flow_matching.solver.utils import toggle_grad
 from flow_matching.utils import gradient, ModelWrapper
 
 
@@ -27,7 +28,7 @@ class ODESolver(Solver):
         super().__init__()
         self.velocity_model = velocity_model
 
-    @torch.no_grad()
+    @toggle_grad
     def sample(
         self,
         x_init: Tensor,
@@ -101,7 +102,7 @@ class ODESolver(Solver):
         else:
             return sol[-1]
 
-    @torch.no_grad()
+    @toggle_grad
     def compute_likelihood(
         self,
         x_1: Tensor,
@@ -174,16 +175,15 @@ class ODESolver(Solver):
         y_init = (x_1, torch.zeros(x_1.shape[0], device=x_1.device))
         ode_opts = {"step_size": step_size} if step_size is not None else {}
 
-        with torch.no_grad():
-            sol, log_det = odeint(
-                dynamics_func,
-                y_init,
-                time_grid,
-                method=method,
-                options=ode_opts,
-                atol=atol,
-                rtol=rtol,
-            )
+        sol, log_det = odeint(
+            dynamics_func,
+            y_init,
+            time_grid,
+            method=method,
+            options=ode_opts,
+            atol=atol,
+            rtol=rtol,
+        )
 
         x_source = sol[-1]
         source_log_p = log_p0(x_source)

--- a/flow_matching/solver/riemannian_ode_solver.py
+++ b/flow_matching/solver/riemannian_ode_solver.py
@@ -12,6 +12,7 @@ from torch import Tensor
 from tqdm import tqdm
 
 from flow_matching.solver.solver import Solver
+from flow_matching.solver.utils import toggle_grad
 from flow_matching.utils import ModelWrapper
 from flow_matching.utils.manifolds import geodesic, Manifold
 
@@ -31,7 +32,7 @@ class RiemannianODESolver(Solver):
         self.manifold = manifold
         self.velocity_model = velocity_model
 
-    @torch.no_grad()
+    @toggle_grad
     def sample(
         self,
         x_init: Tensor,

--- a/flow_matching/solver/utils.py
+++ b/flow_matching/solver/utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the CC-by-NC license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import wraps
+
 import torch
 from torch import Tensor
 
@@ -17,3 +19,12 @@ def get_nearest_times(time_grid: Tensor, t_discretization: Tensor) -> Tensor:
     nearest_indices = distances.argmin(dim=1)
 
     return t_discretization[nearest_indices]
+
+
+def toggle_grad(func):
+    @wraps(func)
+    def wrapper(*args, enable_grad=False, **kwargs):
+        with torch.set_grad_enabled(enable_grad):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/solver/test_ode_solver.py
+++ b/tests/solver/test_ode_solver.py
@@ -97,6 +97,24 @@ class TestODESolver(unittest.TestCase):
                     self.constant_velocity_model.a.grad, 2.0, delta=1e-4
                 )
 
+    def test_no_gradients(self):
+        x_init = torch.tensor([1.0, 0.0])
+        step_size = 0.001
+        time_grid = torch.tensor([0.0, 1.0])
+
+        method = "euler"
+        self.constant_velocity_model.zero_grad()
+        result = self.constant_velocity_solver.sample(
+            x_init=x_init,
+            step_size=step_size,
+            time_grid=time_grid,
+            method=method,
+        )
+        loss = result.sum()
+
+        with self.assertRaises(RuntimeError):
+            loss.backward()
+
     def test_compute_likelihood(self):
         x_1 = torch.tensor([[0.0, 0.0]])
         step_size = 0.1
@@ -113,6 +131,9 @@ class TestODESolver(unittest.TestCase):
         )
         self.assertIsInstance(log_likelihood, Tensor)
         self.assertEqual(x_1.shape[0], log_likelihood.shape[0])
+
+        with self.assertRaises(RuntimeError):
+            log_likelihood.backward()
 
     def test_compute_likelihood_exact_divergence(self):
         x_1 = torch.tensor([[0.0, 0.0]], requires_grad=True)


### PR DESCRIPTION
It was suggested that no part of the core library, such as the sampler and likelihood computation, should be wrapped in `no_grad`. This is because if the code is expected to be integrated into other people's projects, it should not enforce `no_grad` and instead let the user decide whether to track the computation graph. While users can add their own `no_grad`, it is impossible for them to remove a `no_grad` that has already been applied.

This PR removes `no_grad` from the library.

I tested it with the example notebooks and I also added a unit test to make sure we can differentiate through the ode solver and the likelihood computation.