### PR TITLE
Fix SyntaxWarning for invalid escape

### DIFF
--- a/flow_matching/path/path_sample.py
+++ b/flow_matching/path/path_sample.py
@@ -35,7 +35,7 @@ class PathSample:
 
 @dataclass
 class DiscretePathSample:
-    """
+    r"""
     Represents a sample of a conditional-flow generated discrete probability path.
 
     Attributes:

--- a/flow_matching/path/scheduler/scheduler.py
+++ b/flow_matching/path/scheduler/scheduler.py
@@ -63,7 +63,7 @@ class Scheduler(ABC):
 class ConvexScheduler(Scheduler):
     @abstractmethod
     def __call__(self, t: Tensor) -> SchedulerOutput:
-        """Scheduler for convex paths.
+        r"""Scheduler for convex paths.
 
         Args:
             t (Tensor): times in [0,1], shape (...).
@@ -75,7 +75,7 @@ class ConvexScheduler(Scheduler):
 
     @abstractmethod
     def kappa_inverse(self, kappa: Tensor) -> Tensor:
-        """
+        r"""
         Computes :math:`t` from :math:`\kappa_t`.
 
         Args:


### PR DESCRIPTION
Some of the docstrings include latex syntax for math and are considered invalid escape sequences. This is better to be ignored to prevent potential issues.