### PR TITLE
Misleading step size

### DIFF
--- a/examples/2d_flow_matching.ipynb
+++ b/examples/2d_flow_matching.ipynb
@@ -275,23 +275,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# step size for ode solver\n",
-    "step_size = 0.05\n",
-    "\n",
-    "norm = cm.colors.Normalize(vmax=50, vmin=0)\n",
-    "\n",
     "batch_size = 50000  # batch size\n",
-    "eps_time = 1e-2\n",
-    "T = torch.linspace(0,1,10)  # sample times\n",
+    "T = torch.linspace(0,1,10)  # sample times -> step size 0.1\n",
     "T = T.to(device=device)\n",
     "\n",
     "x_init = torch.randn((batch_size, 2), dtype=torch.float32, device=device)\n",
     "solver = ODESolver(velocity_model=wrapped_vf)  # create an ODESolver class\n",
-    "sol = solver.sample(time_grid=T, x_init=x_init, method='midpoint', step_size=step_size, return_intermediates=True)  # sample from the model"
+    "sol = solver.sample(time_grid=T, x_init=x_init, method='midpoint', step_size=None, return_intermediates=True)  # sample from the model"
    ]
   },
   {
@@ -375,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,6 +379,7 @@
     "# compute log likelihood with unbiased hutchinson estimator, average over num_acc\n",
     "num_acc = 10\n",
     "log_p_acc = 0\n",
+    "step_size = 0.5\n",
     "\n",
     "for i in range(num_acc):\n",
     "    _, log_p = solver.compute_likelihood(x_1=x_1, method='midpoint', step_size=step_size, exact_divergence=False, log_p0=gaussian_log_density)\n",


### PR DESCRIPTION
The function `ODESolver.sample()` received a `step_size=0.5` as well as a `time_grid`. This was a little confusing, as the `time_grid` implied a `step_size=0.1`, effectively ignoring the `step_size`. By just passing `step_size=None`, it also reflects more the documentation of that function.

I added the `step_size` to a later cell, where its actually being used.

I further deleted two variable initializations which seem to have no use in this or the following cells.

